### PR TITLE
Add a matrix-key to disambiguate cells in a build matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -6,8 +6,8 @@ on:
     - cron: "0 * * * *" # run once every hour
 
 jobs:
-  integration:
-    name: Integration
+  smoke-test:
+    name: Smoke test
     runs-on: ubuntu-latest
 
     steps:
@@ -35,3 +35,33 @@ jobs:
           buildevents cmd $TRACE_ID $STEP_ID 'sleep some more' -- sleep 2
       - run: |
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'step 2'
+
+  matrix:
+    name: Matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        value: [valueA, valueB]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Buildevents
+        uses: ./
+        with:
+          apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+          dataset: gha-buildevents_integration
+          job-status: ${{ job.status }}
+          matrix-key: ${{ matrix.value }}
+
+      - run: |
+          echo "STEP_ID=0" >> $GITHUB_ENV
+          echo "STEP_START=$(date +%s)" >> $GITHUB_ENV
+      - run: |
+          buildevents cmd $TRACE_ID $STEP_ID ${{ matrix.value }} -- echo The matrix value is ${{ matrix.value }}
+      - run: |
+          buildevents cmd $TRACE_ID $STEP_ID sleep -- sleep 2
+      - run: |
+          buildevents step $TRACE_ID $STEP_ID $STEP_START 'step 1'

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Put the action in the beginning of your worflow:
 
 Name         | Required | Description                                          | Type   | Default
 -------------|----------|------------------------------------------------------|--------|--------
-`apikey`     | yes      | API key used to communicate with the Honeycomb API.  | string | 
+`apikey`     | yes      | API key used to communicate with the Honeycomb API.  | string |
 `dataset`    | yes      | Honeycomb dataset to use.                            | string |
 `job-status` | yes      | The job status, must be set to `${{ job.status }}`.  | string |
+`matrix-key` | no       | Set this to a key unique for this matrix cell.       | string |
 
 ### Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
   job-status:
     description: The job status.
     required: true
+  matrix-key:
+    description: Set this to a key unique for this matrix cell.
+    required: false
 
 #outputs:
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2174,7 +2174,13 @@ function run() {
                 core.debug(`- ${key} = ${process.env[key]}`);
             }
             const buildStart = util.getTimestamp();
-            const traceId = util.replaceSpaces(`${util.getEnv('GITHUB_WORKFLOW')}-${util.getEnv('GITHUB_JOB')}-${util.getEnv('GITHUB_RUN_NUMBER')}`);
+            const traceComponents = [
+                util.getEnv('GITHUB_WORKFLOW'),
+                util.getEnv('GITHUB_JOB'),
+                util.getEnv('GITHUB_RUN_NUMBER'),
+                core.getInput('matrix-key')
+            ];
+            const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'));
             // save buildStart to be used in the post section
             core.saveState('buildStart', buildStart.toString());
             const apikey = core.getInput('apikey', { required: true });
@@ -2217,6 +2223,7 @@ function runPost() {
                 'github.head_ref': util.getEnv('GITHUB_HEAD_REF'),
                 'github.base_ref': util.getEnv('GITHUB_BASE_REF'),
                 'github.job': util.getEnv('GITHUB_JOB'),
+                'github.matrix-key': core.getInput('matrix-key'),
                 'runner.os': util.getEnv('RUNNER_OS'),
                 'job.status': jobStatus
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,13 @@ async function run(): Promise<void> {
     }
 
     const buildStart = util.getTimestamp()
-    const traceId = util.replaceSpaces(
-      `${util.getEnv('GITHUB_WORKFLOW')}-${util.getEnv('GITHUB_JOB')}-${util.getEnv('GITHUB_RUN_NUMBER')}`
-    )
+    const traceComponents = [
+      util.getEnv('GITHUB_WORKFLOW'),
+      util.getEnv('GITHUB_JOB'),
+      util.getEnv('GITHUB_RUN_NUMBER'),
+      core.getInput('matrix-key')
+    ]
+    const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
 
     // save buildStart to be used in the post section
     core.saveState('buildStart', buildStart.toString())
@@ -62,6 +66,7 @@ async function runPost(): Promise<void> {
       'github.head_ref': util.getEnv('GITHUB_HEAD_REF'),
       'github.base_ref': util.getEnv('GITHUB_BASE_REF'),
       'github.job': util.getEnv('GITHUB_JOB'), // undocumented
+      'github.matrix-key': core.getInput('matrix-key'),
       'runner.os': util.getEnv('RUNNER_OS'), // undocumented
       'job.status': jobStatus
     })


### PR DESCRIPTION
When running in a matrix job, set `matrix-key` to something uniquely
identifying the cell it is running in. This then is used to create
separate traces for each cell.

This addresses #13 