### PR TITLE
Add GITHUB_RUN_ID to the traceId components

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2178,7 +2178,8 @@ function run() {
                 util.getEnv('GITHUB_WORKFLOW'),
                 util.getEnv('GITHUB_JOB'),
                 util.getEnv('GITHUB_RUN_NUMBER'),
-                core.getInput('matrix-key')
+                core.getInput('matrix-key'),
+                util.getEnv('GITHUB_RUN_ID')
             ];
             const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'));
             // save buildStart to be used in the post section

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ async function run(): Promise<void> {
       util.getEnv('GITHUB_WORKFLOW'),
       util.getEnv('GITHUB_JOB'),
       util.getEnv('GITHUB_RUN_NUMBER'),
-      core.getInput('matrix-key')
+      core.getInput('matrix-key'),
+      util.getEnv('GITHUB_RUN_ID')
     ]
     const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
 


### PR DESCRIPTION
If a workflow is re-run, it will use the same GITHUB_RUN_NUMBER as the previous run. This would cause gha-buildevents to produce two traces with the exact same trace ID. By adding the run ID to the trace ID, each run should be uniquely identified.

Fixes #16