### PR TITLE
Allow users to add/override fields

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5435,8 +5435,15 @@ function install(apikey, dataset) {
 }
 exports.install = install;
 function addFields(keyValueMap) {
-    fs.writeFileSync('../buildevents.txt', logfmt.stringify(keyValueMap));
-    util.setEnv('BUILDEVENT_FILE', '../buildevents.txt');
+    const envPath = util.getEnv('BUILDEVENT_FILE') || '../buildevents.txt';
+    // Add the existing values from the BUILDEVENT_FILE to the fields we write out
+    // this deliberately lets existing values - presumably from the workflow - override
+    // the defaults we set.
+    if (fs.existsSync(envPath)) {
+        Object.assign(keyValueMap, logfmt.parse(fs.readFileSync(envPath).toString()));
+    }
+    fs.writeFileSync(envPath, logfmt.stringify(keyValueMap));
+    util.setEnv('BUILDEVENT_FILE', envPath);
 }
 exports.addFields = addFields;
 function build(buildId, buildStart, result) {

--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -28,8 +28,15 @@ export async function install(apikey: string, dataset: string): Promise<void> {
 }
 
 export function addFields(keyValueMap: object): void {
-  fs.writeFileSync('../buildevents.txt', logfmt.stringify(keyValueMap))
-  util.setEnv('BUILDEVENT_FILE', '../buildevents.txt')
+  const envPath = util.getEnv('BUILDEVENT_FILE') || '../buildevents.txt'
+  // Add the existing values from the BUILDEVENT_FILE to the fields we write out
+  // this deliberately lets existing values - presumably from the workflow - override
+  // the defaults we set.
+  if (fs.existsSync(envPath)) {
+    Object.assign(keyValueMap, logfmt.parse(fs.readFileSync(envPath).toString()))
+  }
+  fs.writeFileSync(envPath, logfmt.stringify(keyValueMap))
+  util.setEnv('BUILDEVENT_FILE', envPath)
 }
 
 export async function build(buildId: string, buildStart: string, result: string): Promise<void> {


### PR DESCRIPTION
This allows users of this action to specify additional fields through the
file at $BUILDEVENT_FILE. Any values specified in there override the
defaults provided by gha-buildevents.

This fixes #3.