### PR TITLE
Enable detection of gha-buildevents created spans

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2225,7 +2225,8 @@ function runPost() {
                 'github.job': util.getEnv('GITHUB_JOB'),
                 'github.matrix-key': core.getInput('matrix-key'),
                 'runner.os': util.getEnv('RUNNER_OS'),
-                'job.status': jobStatus
+                'job.status': jobStatus,
+                'meta.source': 'gha-buildevents'
             });
             yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), postStart.toString(), 'gha-buildevents_post');
             yield buildevents.build(traceId, buildStart, result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,8 @@ async function runPost(): Promise<void> {
       'github.job': util.getEnv('GITHUB_JOB'), // undocumented
       'github.matrix-key': core.getInput('matrix-key'),
       'runner.os': util.getEnv('RUNNER_OS'), // undocumented
-      'job.status': jobStatus
+      'job.status': jobStatus,
+      'meta.source': 'gha-buildevents'
     })
 
     await buildevents.step(traceId, util.randomInt(2 ** 32).toString(), postStart.toString(), 'gha-buildevents_post')


### PR DESCRIPTION
This adds a `meta.source` top-level field to all events so that users can
easily distinguish between this and other sourced events.