### PR TITLE
Make the TRACE_ID unique across repos and re-runs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2175,10 +2175,12 @@ function run() {
             }
             const buildStart = util.getTimestamp();
             const traceComponents = [
+                util.getEnv('GITHUB_REPOSITORY'),
                 util.getEnv('GITHUB_WORKFLOW'),
                 util.getEnv('GITHUB_JOB'),
                 util.getEnv('GITHUB_RUN_NUMBER'),
-                core.getInput('matrix-key')
+                core.getInput('matrix-key'),
+                util.randomInt(Math.pow(2, 32)).toString()
             ];
             const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'));
             // save buildStart to be used in the post section

--- a/dist/index.js
+++ b/dist/index.js
@@ -2180,6 +2180,7 @@ function run() {
                 util.getEnv('GITHUB_JOB'),
                 util.getEnv('GITHUB_RUN_NUMBER'),
                 core.getInput('matrix-key'),
+                // append a random number to ensure traceId is unique when the workflow is re-run
                 util.randomInt(Math.pow(2, 32)).toString()
             ];
             const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ async function run(): Promise<void> {
       util.getEnv('GITHUB_JOB'),
       util.getEnv('GITHUB_RUN_NUMBER'),
       core.getInput('matrix-key'),
+      // append a random number to ensure traceId is unique when the workflow is re-run
       util.randomInt(2 ** 32).toString()
     ]
     const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ async function run(): Promise<void> {
 
     const buildStart = util.getTimestamp()
     const traceComponents = [
+      util.getEnv('GITHUB_REPOSITORY'),
       util.getEnv('GITHUB_WORKFLOW'),
       util.getEnv('GITHUB_JOB'),
       util.getEnv('GITHUB_RUN_NUMBER'),
-      core.getInput('matrix-key')
+      core.getInput('matrix-key'),
+      util.randomInt(2 ** 32).toString()
     ]
     const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
 


### PR DESCRIPTION
This change adds the repo name and a random suffix to TRACE_ID. Otherwise
this ID would not be unique across repositories and re-runs (which preserve
the RUN_ID, see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables).

This fixes #16.