### PR TITLE
Use absolute path for BUILDEVENTS_FILE

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5447,7 +5447,7 @@ function addFields(keyValueMap) {
     const BUILDEVENT_FILE = 'BUILDEVENT_FILE';
     let envPath = util.getEnv(BUILDEVENT_FILE);
     if (!envPath) {
-        envPath = '../buildevents.txt';
+        envPath = path.resolve('../buildevents.txt');
         util.setEnv(BUILDEVENT_FILE, envPath);
     }
     // Add the existing values from the BUILDEVENT_FILE to the fields we write out

--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -33,7 +33,7 @@ export function addFields(keyValueMap: object): void {
 
   let envPath = util.getEnv(BUILDEVENT_FILE)
   if (!envPath) {
-    envPath = '../buildevents.txt'
+    envPath = path.resolve('../buildevents.txt')
     util.setEnv(BUILDEVENT_FILE, envPath)
   }
   // Add the existing values from the BUILDEVENT_FILE to the fields we write out


### PR DESCRIPTION
Fixes #38 

Tested locally like this:

![image](https://user-images.githubusercontent.com/1320357/109366330-04e49600-7848-11eb-98a7-b537227ff498.png)
